### PR TITLE
Updated hyperlinks under the Tips For Better Code section.

### DIFF
--- a/list/to_c_or_not_to_c.md
+++ b/list/to_c_or_not_to_c.md
@@ -130,9 +130,9 @@ Below is the "experimental zone"; ie. projects that aren't finished yet, but tha
 
 # Tips For Better Code
 
-The *very first thing* to do **in all cases** is to [read the docs](http://gbdev.gg8.se/wiki/articles/Pan_Docs), to grasp how the Game Boy works. In ASM, this is essential; in C, this will let you understand what a given library function does. It will also let you understand what is possible on the Game Boy, and what isn't. (You can always ask, if you have doubts.)
+The *very first thing* to do **in all cases** is to [read the docs](https://gbdev.io/pandocs/), to grasp how the Game Boy works. In ASM, this is essential; in C, this will let you understand what a given library function does. It will also let you understand what is possible on the Game Boy, and what isn't. (You can always ask, if you have doubts.)
 
-I also recommend looking up [awesome-gbdev](http://github.com/avivace/awesome-gbdev) for resources and tutorials. There are a lot of helpful articles there, as well as helper tools.
+I also recommend looking up [awesome-gbdev](https://gbdev.io/list.html) for resources and tutorials. There are a lot of helpful articles there, as well as helper tools.
 
 
 ## ASM Help


### PR DESCRIPTION
I wasn't positive if the links were left for historical purposes or not but I noticed while reading that the pan doc linked was considered depreciated, and that the awesome-gbdev link went to the github instead of the website rendition.
Apologies if I'm doing things out of order, I'm unfamiliar regarding shared repositories.