### PR TITLE
Add TRSE under "Development tools"

### DIFF
--- a/list/list.md
+++ b/list/list.md
@@ -244,6 +244,7 @@ The [To C Or Not To C](https://gist.github.com/ISSOtm/4f4d335c3fd258ad0dfc7d4d61
 - [romusage](https://github.com/bbbbbr/romusage) - Command line tool for estimating usage (free space) of Game Boy ROMs from a .map, .noi or ihx file. Works with GBDK-2020 and RGBDS.
 - [awake](https://github.com/devdri/awake) - Game Boy decompiler.
 - [Game Boy Text Tools](https://github.com/raphaklaus/gameboy-text-tools) - Set of tools for text manipulation and translation of Game Boy ROMs written in Node.js.
+- [Turbo Rascal Syntax error, “;” expected but “BEGIN”)](https://lemonspawn.com/turbo-rascal-syntax-error-expected-but-begin/) - Complete suite (IDE, compiler, programming language, resource editor) intended for developing games/demos for 8 / 16-bit line of computers, including the Game Boy and Game Boy Color.
 
 #### Graphics utilities
 


### PR DESCRIPTION
Note: TRSE includes its own compiler for it's Pascal-like programming language, so it could maybe also be listed under "Software Development > Compilers".