### PR TITLE
Use upcoming canonical URL for gb-asm-tutorial

### DIFF
--- a/list/.vuepress/config.js
+++ b/list/.vuepress/config.js
@@ -28,7 +28,7 @@ module.exports = {
         children: [
           ['/guides/tools', 'Choosing development tools'],
           ['/guides/asmstyle', 'ASM Style recomendations'],
-          ['https://eldred.fr/gb-asm-tutorial/index.html', 'GB ASM Programming Guide']
+          ['https://eldred.fr/gb-asm-tutorial', 'GB ASM Programming Guide']
         ]
       },],
       sidebarDepth: 2,


### PR DESCRIPTION
The "index.html" part is not guaranteed to stay; however, "/gb-asm-tutorial" is guaranteed to permalink (or at least redirect) to the tutorial landing page.