### PR TITLE
Update Homebrew Hub URL in Resources

### DIFF
--- a/website/resources.md
+++ b/website/resources.md
@@ -369,7 +369,7 @@ Fragments of code, effects, proof of concepts and generally non complete games.
 
 Complete and open source games.
 
-- [Homebrew Hub](https://gbhh.avivace.com) - Every unofficial homebrew ever produced for Game Boy playable online (mobile/touch too): a community-lead attempt to collect, archive and save every unofficial game, homebrew, demo, patch, hackrom for Game Boy (Color) produced by the community through years of passionate work.
+- [Homebrew Hub](https://hh.gbdev.io) - Every unofficial homebrew ever produced for Game Boy playable online (mobile/touch too): a community-lead attempt to collect, archive and save every unofficial game, homebrew, demo, patch, hackrom for Game Boy (Color) produced by the community through years of passionate work.
 
 ### ASM
 


### PR DESCRIPTION
Currently the document points at the old URL (which no longer works)