### PR TITLE
GBCompo23: add resource links for GBSDK

### DIFF
--- a/website/gbcompo23.md
+++ b/website/gbcompo23.md
@@ -70,6 +70,9 @@ Here is a curated list tools and documentation to get you started.
 - [GBStudio](https://www.gbstudio.dev/) (no coding required)
   - [Resources to get started](https://gbstudiocentral.com/resources/)
   - [Dedicated Discord](https://discord.gg/knRryZWGcm)
+- [GBSDK](https://github.com/daid/gbsdk) (C + RGBDS ASM, without a standard library)
+  - [Documentation](https://daid.github.io/gbsdk/)
+  - [Source for a game](https://github.com/QuinnPainter/CrossConnect) and [another game](https://github.com/QuinnPainter/Wyrmhole) built with GBSDK
 
 ## Sponsors
 


### PR DESCRIPTION
Just a suggestion, if people are inclined to add this to the resources section as a tool option.

Note, two of the linked resources are specific game implementations since those are the only two fully implemented examples i know of that exist. For those who might use this tool they could be useful references.