### PR TITLE
Update Twitter link in contributing.md to point to nitter.net instead

### DIFF
--- a/website/contributing.md
+++ b/website/contributing.md
@@ -47,7 +47,7 @@ For non-disruptive PRs:
 
 ## References
 
-[1](https://twitter.com/matteocollina/status/1359087694375174145)
+[1](https://nitter.net/matteocollina/status/1359087694375174145)
 
 ## Where can I help?
 


### PR DESCRIPTION
Twitter only shows the reply chain for logged-in users, which makes it inaccessible for many people. On the other hand, nitter.net will mirror the entire reply chain happily.