### PR TITLE
add redirect from old title of "Choosing tools"

### DIFF
--- a/website/to_c_or_not_to_c.md
+++ b/website/to_c_or_not_to_c.md
@@ -1,0 +1,17 @@
+---
+sidebar: false
+head:
+  - - meta
+    - http-equiv: refresh
+      content: 10; url=https://gbdev.io/guides/tools.html
+  - - link
+    - rel: canonical
+      href: https://gbdev.io/guides/tools.html
+---
+
+# To C or not to C
+
+This guide has been moved to
+"[Choosing tools for Game Boy development](guides/tools.html)".
+Please update your bookmarks and ask other website operators
+to update inbound links.

--- a/website/to_c_or_not_to_c.md
+++ b/website/to_c_or_not_to_c.md
@@ -13,5 +13,8 @@ head:
 
 This guide has been moved to
 "[Choosing tools for Game Boy development](guides/tools.html)".
+
 Please update your bookmarks and ask other website operators
 to update inbound links.
+
+In 10 seconds, you'll be redirected.


### PR DESCRIPTION
The article used to be called "To C or not to C" before anti-SDCC snark was toned down. Repair inbound links to the old title with this signpost.

Because GitHub Pages doesn't appear to support HTTP redirects (status 301 Moved Permanently), attempt to use meta refresh as a substitute. This attempt will need help with testing by those with the privilege to do so.

The corresponding issue was filed against the wrong repository (https://github.com/gbdev/gbdev.github.io/issues/83).